### PR TITLE
updated packaging for cowbuilder-dist

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,9 @@ Maintainer: James Thomas <james.thomas@codethink.co.uk>
 Build-Depends: debhelper (>= 5),
 	       quilt,
                qtbase5-dev,
+               qt5-qmake,
+               qt5-default,
+               qtdeclarative5-dev,
                doxygen,
                libtracker-sparql-0.16-dev,
 	       libiodbc2-dev


### PR DESCRIPTION
Added packages so that cowbuilder-dist will compile a package on Ubuntu, tested with:

```
cowbuilder-dist trusty i386 create 
cowbuilder-dist trusty i386 build ../libqtsparql_0.2.6~unreleased.dsc 
```
