### PR TITLE
Support for Ubuntu 16.04 LTS.

### DIFF
--- a/.package.usage
+++ b/.package.usage
@@ -1,0 +1,6 @@
+HOW TO PREPARE BUILD ENVIRONMENT
+  ./package setup
+
+HOW TO COMPILE A DEB PACKAGE
+  ./package build
+

--- a/config.tests/unix/tracker-sparql/tracker-sparql.pro
+++ b/config.tests/unix/tracker-sparql/tracker-sparql.pro
@@ -3,5 +3,5 @@ CONFIG -= qt
 
 unix: {
     CONFIG += link_pkgconfig
-    PKGCONFIG += tracker-sparql-0.16
+    PKGCONFIG += tracker-sparql-1.0
 }

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 5),
                qt5-default,
                qtdeclarative5-dev,
                doxygen,
-               libtracker-sparql-0.16-dev,
+               libtracker-sparql-1.0-dev,
 	       libiodbc2-dev
 Standards-Version: 3.9.1
 
@@ -36,13 +36,13 @@ Depends: libqtsparql0 (= ${binary:Version}),
          ${misc:Depends}
 Description: Library for accessing RDF stores.
 
-Package: libqtsparql-doc
-Section: doc
-Architecture: all
-Depends: ${misc:Depends}
-Description: Library for accessing RDF stores.
- .
- This package contains the documentation.
+#Package: libqtsparql-doc
+#Section: doc
+#Architecture: all
+#Depends: ${misc:Depends}
+#Description: Library for accessing RDF stores.
+# .
+# This package contains the documentation.
 
 Package: libqtsparql-tests
 Section: devel

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ build: debian/build-stamp
 debian/build-stamp: Makefile $(QUILT_STAMPFN)
 	dh_testdir
 	$(MAKE)
-	$(MAKE) doc
+	#$(MAKE) doc
 	touch $@
 
 clean: unpatch

--- a/package
+++ b/package
@@ -1,0 +1,57 @@
+#!/bin/bash
+####################################################################
+#
+# This script provides two helpers. One for preparing a cowbuilder
+# environment for compiling and another one for building
+# the actual package.
+#
+# USAGE:
+#
+#  This will prepare the environment on your Ubuntu 16.04 LTS:
+#   ./package setup
+#
+#  And after that you can use this command to compile the package:
+#   ./package build
+#
+#
+# Author: Juhapekka Piiroinen <juhapekka.piiroinen@link-motion.com>
+# License: LGPL v2.1
+#
+# (C) Link Motion Oy
+####################################################################
+set -e
+
+CMD=$1
+SCRIPTPATH=`dirname $0`
+
+pushd ${SCRIPTPATH} > /dev/null
+echo ${CMD}
+
+if [[ -z ${CMD} ]]; then
+  cat .package.usage
+  exit 1
+fi
+
+if [[ "${CMD}" == "setup" ]]; then
+  echo
+  echo "This will install the development tools."
+  echo
+  echo "press <enter> to continue or ctrl+c to cancel."
+  read
+  sudo apt-get install ubuntu-dev-tools debhelper cowbuilder
+  cowbuilder-dist xenial amd64 create
+  echo "Build environment is now ready."
+  exit 0
+elif [[ "${CMD}" == "build" ]]; then
+  echo
+  echo "You are about to build a deb package."
+  echo
+  echo "press <enter> to continue or ctrl+c to cancel."
+  read
+
+  debuild -S -us -uc
+  cowbuilder-dist xenial amd64 build ../libqtsparql_0.2.6~unreleased.dsc
+  echo "Package is now built and is available at ~/pbuilder/xenial_results/"
+else
+  cat .package.usage
+fi

--- a/projects.pro
+++ b/projects.pro
@@ -18,7 +18,7 @@ SUBDIRS = src tests examples
 xclean.commands = rm -rf lib plugins include
 xclean.depends = clean
 
-include(doc/doc.pri)
+#include(doc/doc.pri)
 
 check.CONFIG = recursive
 check.recurse = tests

--- a/src/plugins/sparqldrivers/tracker_direct/tracker_direct.pro
+++ b/src/plugins/sparqldrivers/tracker_direct/tracker_direct.pro
@@ -16,7 +16,7 @@ SOURCES         = main.cpp \
 
 unix: {
     CONFIG += link_pkgconfig
-    PKGCONFIG += tracker-sparql-0.16
+    PKGCONFIG += tracker-sparql-1.0
 }
 
 include(../qsparqldriverbase.pri)

--- a/src/plugins/sparqldrivers/virtuoso/main.cpp
+++ b/src/plugins/sparqldrivers/virtuoso/main.cpp
@@ -37,7 +37,7 @@
 **
 ****************************************************************************/
 
-#include <QtSparql/private/qsparqldriverplugin_p.h>
+#include <private/qsparqldriverplugin_p.h>
 #include <qstringlist.h>
 #include "../../../sparql/drivers/virtuoso/qsparql_virtuoso_p.h"
 

--- a/src/sparql/drivers/virtuoso/qsparql_virtuoso.cpp
+++ b/src/sparql/drivers/virtuoso/qsparql_virtuoso.cpp
@@ -57,12 +57,12 @@
 #include <QtCore/QMutexLocker>
 #include <QtCore/QThread>
 
-#include <QtSparql/qsparqlerror.h>
-#include <QtSparql/qsparqlbinding.h>
-#include <QtSparql/qsparqlresultrow.h>
-#include <QtSparql/qsparqlquery.h>
-#include <QtSparql/qsparqlqueryoptions.h>
-#include <QtSparql/private/qsparqlntriples_p.h>
+#include <qsparqlerror.h>
+#include <qsparqlbinding.h>
+#include <qsparqlresultrow.h>
+#include <qsparqlquery.h>
+#include <qsparqlqueryoptions.h>
+#include <private/qsparqlntriples_p.h>
 #define XSD_DATE
 #include "../../kernel/qsparqlxsd_p.h"
 

--- a/src/sparql/drivers/virtuoso/qsparql_virtuoso_p.h
+++ b/src/sparql/drivers/virtuoso/qsparql_virtuoso_p.h
@@ -40,8 +40,8 @@
 #ifndef QSPARQL_VIRTUOSO_H
 #define QSPARQL_VIRTUOSO_H
 
-#include <QtSparql/private/qsparqldriver_p.h>
-#include <QtSparql/qsparqlresult.h>
+#include <private/qsparqldriver_p.h>
+#include <qsparqlresult.h>
 
 #if defined (Q_OS_WIN32)
 #include <QtCore/qt_windows.h>

--- a/tests/auto/qsparql_benchmark/qsparql_benchmark.pro
+++ b/tests/auto/qsparql_benchmark/qsparql_benchmark.pro
@@ -1,6 +1,6 @@
 include(../sparqltest.pri)
 CONFIG += qt warn_on console depend_includepath testcase link_pkgconfig
-PKGCONFIG = tracker-sparql-0.16
+PKGCONFIG = tracker-sparql-1.0
 QT += testlib xml
 SOURCES  += tst_qsparql_benchmark.cpp
 


### PR DESCRIPTION
Changed dependency from libtracker-sparql-0.16-dev to libtracker-sparql-1.0-dev.
Disabled doc package and compiling.
Added 'package' helper script for creating the deb package.
